### PR TITLE
Add HGDP,TGP, and pop option to subset

### DIFF
--- a/utils/subset_vcf_for_phase.py
+++ b/utils/subset_vcf_for_phase.py
@@ -174,6 +174,7 @@ def main(args):
             & hl.is_snp(mt.alleles[0], mt.alleles[1])
             & (bi_allelic_expr(mt))
         )
+        mt = mt.select_entries("GT", "GQ", "DP", "AD", "PL")
 
         mt = mt.checkpoint(
             f"{output_path}/{contig}/{contig}_dense_bia_snps.mt",

--- a/utils/subset_vcf_for_phase.py
+++ b/utils/subset_vcf_for_phase.py
@@ -228,7 +228,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--test",
-        help="Subset to 2 partitions.",
+        help="Subset to 2 partitions and variants on chr1.",
         action="store_true",
     )
     parser.add_argument(

--- a/utils/subset_vcf_for_phase.py
+++ b/utils/subset_vcf_for_phase.py
@@ -1,25 +1,19 @@
 # noqa: D100
+import argparse
 import logging
-from typing import List, Optional
+from typing import Optional
 
 import hail as hl
-from gnomad.resources.config import (
-    gnomad_public_resource_configuration,
-    GnomadPublicResourceSource,
-)
-from gnomad.sample_qc.pipeline import filter_rows_for_qc
 
+from gnomad.utils.annotations import bi_allelic_expr
 
 from gnomad_qc.v3.resources.basics import get_gnomad_v3_vds
 from gnomad_qc.v4.resources.meta import meta
+from gnomad_qc.v4.resources.release import release_sites
 
 logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-
-gnomad_public_resource_configuration.source = (
-    GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS
-)
 
 CONTIGS = [
     "chr1",
@@ -49,7 +43,7 @@ CONTIGS = [
 
 def get_subset_samples(
     samples_path: Optional[str] = None,
-    pops: Optional[List[str]] = None,
+    pop: Optional[str] = None,
     hgdp: bool = False,
     tgp: bool = False,
 ) -> hl.Table:
@@ -57,15 +51,16 @@ def get_subset_samples(
     Get samples to subset out of v3 VDS.
 
     :param samples_path: Path to TSV of sample IDs to subset to. The TSV must have a header of 's'.
-    :param pops: Optional list of populations to include in subset. Defaults to None.
+    :param pop: Optional str of genetic ancestry group to include in subset. Defaults to None.
     :param hgdp: Boolean of whether to include HGDP in subset. Defaults to False.
     :param tgp: Boolean of whether to include TGP in subset. Defaults to False.
+    :return: Table of samples to subset to.
     """
     meta_ht = meta(data_type="genomes").ht()
     samples_to_keep = []
 
     def _add_filtered_meta(condition):
-        ht_to_add = meta_ht.filter(condition).select()
+        ht_to_add = meta_ht.filter(condition)
         samples_to_keep.append(ht_to_add)
 
     if samples_path:
@@ -73,11 +68,9 @@ def get_subset_samples(
         sample_ht = sample_ht.select()
 
     # Select released samples with infered population
-    if pops:
-        pops_to_keep = hl.literal(pops)
+    if pop:
         _add_filtered_meta(
-            (pops_to_keep.contains(meta_ht.population_inference.pop))
-            & (meta_ht.release)
+            (pop == meta_ht.population_inference.pop) & (meta_ht.release)
         )
 
     # Keep HGDP samples in subset
@@ -118,20 +111,32 @@ def main(args):
     min_callrate = args.min_callrate
     min_af = args.min_af
     test = args.test
-    contigs = CONTIGS if not contigs else contigs
+    pop = args.pop
+    hgdp = args.hgdp
+    tgp = args.tgp
+    contigs = args.contigs
 
-    # TODO: Come back to args needed in get_gnomad_v3_vds
     logger.info("Running script on %s...", contigs)
     vds = get_gnomad_v3_vds()
+    release = release_sites("genomes").ht()
+
+    # Get genetic ancestry group index in freq array
+    pop_idx = hl.eval(release.freq_index_dict[f"{pop}_adj"])
 
     if test:
         vds = hl.vds.VariantDataset(
             vds.reference_data._filter_partitions(range(2)),
             vds.variant_data._filter_partitions(range(2)),
         )
-
+    logger.info("Retrieving samples to subset to...")
     sample_ht = get_subset_samples(
-        samples_path=args.samples_path, pops=args.pops, hgdp=args.hgdp, tgp=args.tgp
+        samples_path=args.samples_path, pop=pop, hgdp=hgdp, tgp=tgp
+    )
+
+    logger.info("Checkpointing sample table...")
+    sample_file_name = f"{pop}_samples{'_with' if hgdp or tgp else ''}{'_hgdp' if hgdp else ''}{'_tgp' if tgp else ''}.ht"
+    sample_ht = sample_ht.checkpoint(
+        f"{output_path}/{sample_file_name}", overwrite=args.overwrite
     )
 
     logger.info("Subsetting to %d samples", sample_ht.count())
@@ -141,51 +146,64 @@ def main(args):
         "Applying min_rep to the variant data MT because remove_dead_alleles may "
         "result in variants that do not have the minimum representation."
     )
-    vd = vds.variant_data
     vds = hl.vds.VariantDataset(
         vds.reference_data,
-        vd.key_rows_by(**hl.min_rep(vd.locus, vd.alleles)),
+        vds.variant_data.key_rows_by(
+            **hl.min_rep(vds.variant_data.locus, vds.variant_data.alleles)
+        ),
     )
 
     for contig in contigs:
         logger.info("Subsetting %s...", contig)
-        vds = hl.vds.filter_intervals(
-            vds,
-            [hl.parse_locus_interval(contig, reference_genome="GRCh38")],
-        )
+        vds = hl.vds.filter_chromosomes(vds, keep=contig)
         vds = hl.vds.split_multi(vds, filter_changed_loci=True)
         mt = hl.vds.to_dense_mt(vds)
         mt = mt.drop("gvcf_info")
 
-        # TODO: See if this is needed: mt = mt.filter_rows(hl.agg.any(mt.GT.is_non_ref()))
+        logger.info("Annotating with %s AF and info fields...", pop)
+        mt = mt.annotate_rows(
+            pop_AF=release[mt.row_key].freq[pop_idx].AF,
+            info=hl.struct(
+                QD=release[mt.row_key].info.QD,
+                FS=release[mt.row_key].info.FS,
+                MQ=release[mt.row_key].info.MQ,
+            ),
+            site_callrate=hl.agg.fraction(hl.is_defined(mt.GT)),
+        )
+
         logger.info(
-            "Filtering to variants with greater than %f callrate and %f allele frequency",
+            "Filtering to biallelic SNPs with greater than %f callrate and %f allele frequency",
             min_callrate,
             min_af,
         )
-        mt = filter_rows_for_qc(
-            mt,
-            min_callrate=min_callrate,
-            min_af=min_af,
-            min_inbreeding_coeff_threshold=None,
-            min_hardy_weinberg_threshold=None,
+        mt = mt.filter_rows(
+            (mt.site_callrate > min_callrate)
+            & (mt.pop_AF > min_af)
+            & hl.is_snp(mt.alleles[0], mt.alleles[1])
+            & (bi_allelic_expr(mt))
         )
+
         mt = mt.checkpoint(
             f"{output_path}/{contig}/{contig}_dense_bia_snps.mt",
             overwrite=True,
         )
 
-        logger.info("Exporting VCF for %s...", contig)
+        logger.info(
+            "Exporting VCF for %s... with %s variants across %s samples",
+            contig,
+            mt.count_rows(),
+            mt.count_cols(),
+        )
+        # Export as a single VCF, a requirement for phasing tools
         hl.export_vcf(
-            mt, f"{output_path}{contig}/{contig}_dense_bia_snps.vcf.bgz", tabix=True
+            mt,
+            f"{output_path}/{contig}/{contig}_{pop}_dense_bia_snps.vcf.bgz",
+            tabix=True,
         )
 
 
 if __name__ == "__main__":
-    import argparse
-
     parser = argparse.ArgumentParser()
-    parser.add_argument("--mt-path", help="MatrixTable to subset from", required=True)
     parser.add_argument(
         "--samples-path",
         help="TSV of samples, expects the TSV to have a header with the label `s`",
@@ -207,11 +225,11 @@ if __name__ == "__main__":
         "--contigs",
         nargs="+",
         help="Integer contigs to run subsetting on",
+        default=CONTIGS,
     )
     parser.add_argument(
-        "--pops",
-        nargs="+",
-        help="Populations to include in subset",
+        "--pop",
+        help="Population to include in subset",
     )
     parser.add_argument(
         "--tgp",
@@ -226,6 +244,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "--test",
         help="Subset to 2 partitions",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--overwrite",
+        help="Overwrite existing files",
         action="store_true",
     )
     args = parser.parse_args()

--- a/utils/subset_vcf_for_phase.py
+++ b/utils/subset_vcf_for_phase.py
@@ -93,7 +93,7 @@ def main(args):
     min_callrate = args.min_callrate
     min_af = args.min_af
     test = args.test
-    af_pop = args.pop
+    af_pop = args.af_pop
     subset_pop = args.subset_pop
     hgdp = args.hgdp
     tgp = args.tgp

--- a/utils/subset_vcf_for_phase.py
+++ b/utils/subset_vcf_for_phase.py
@@ -21,6 +21,31 @@ gnomad_public_resource_configuration.source = (
     GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS
 )
 
+CONTIGS = [
+    "chr1",
+    "chr2",
+    "chr3",
+    "chr4",
+    "chr5",
+    "chr6",
+    "chr7",
+    "chr8",
+    "chr9",
+    "chr10",
+    "chr11",
+    "chr12",
+    "chr13",
+    "chr14",
+    "chr15",
+    "chr16",
+    "chr17",
+    "chr18",
+    "chr19",
+    "chr20",
+    "chr21",
+    "chr22",
+]
+
 
 def get_subset_samples(
     samples_path: Optional[str] = None,
@@ -93,6 +118,7 @@ def main(args):
     min_callrate = args.min_callrate
     min_af = args.min_af
     test = args.test
+    contigs = CONTIGS if not contigs else contigs
 
     # TODO: Come back to args needed in get_gnomad_v3_vds
     logger.info("Running script on %s...", contigs)
@@ -122,7 +148,6 @@ def main(args):
     )
 
     for contig in contigs:
-        contig = f"chr{contig}"
         logger.info("Subsetting %s...", contig)
         vds = hl.vds.filter_intervals(
             vds,
@@ -182,7 +207,6 @@ if __name__ == "__main__":
         "--contigs",
         nargs="+",
         help="Integer contigs to run subsetting on",
-        required=True,
     )
     parser.add_argument(
         "--pops",

--- a/utils/subset_vcf_for_phase.py
+++ b/utils/subset_vcf_for_phase.py
@@ -114,7 +114,6 @@ def main(args):
     pop = args.pop
     hgdp = args.hgdp
     tgp = args.tgp
-    contigs = args.contigs
     overwrite = args.overwrite
 
     logger.info("Running script on %s...", contigs)
@@ -153,11 +152,13 @@ def main(args):
         logger.info("Annotating with %s AF and info fields...", pop)
         mt = mt.annotate_rows(
             info=hl.struct(
-                QD=release[mt.row_key].info.QD,
-                FS=release[mt.row_key].info.FS,
-                MQ=release[mt.row_key].info.MQ,
-                pop_AF=release[mt.row_key].freq[pop_idx].AF,
-                site_callrate=hl.agg.fraction(hl.is_defined(mt.GT)),
+                **{
+                    "QD": release[mt.row_key].info.QD,
+                    "FS": release[mt.row_key].info.FS,
+                    "MQ": release[mt.row_key].info.MQ,
+                    f"{pop}_AF": release[mt.row_key].freq[pop_idx].AF,
+                    "site_callrate": hl.agg.fraction(hl.is_defined(mt.GT)),
+                }
             ),
             filters=release[mt.row_key].filters,
         )
@@ -169,7 +170,7 @@ def main(args):
         )
         mt = mt.filter_rows(
             (mt.info.site_callrate > min_callrate)
-            & (mt.info.pop_AF > min_af)
+            & (mt.info[f"{pop}_AF"] > min_af)
             & hl.is_snp(mt.alleles[0], mt.alleles[1])
             & (bi_allelic_expr(mt))
         )


### PR DESCRIPTION
This updates the pre-phasing subset code to allow for genetic ancestry group selection and adding in HGDP and TGP samples. The script now uses the gnomAD v3 VDS. It also uses the v4 release for AF, info, and filter field annotations. 

The purpose of the script is to subset gnomAD to an admixed group, e.g. 'amr'  or 'afr', filter to high coverage (callrate >0.9), common  (genetic ancestry group AF > 0.1%)  bi-allelic SNPs, as phasing needs high callrate SNPs and local ancestry inference cannot be done with confidence on rare sites. The script then exports a single VCF per chromosome because it is required for the phasing tool.

I've added the option to include HGDP and TGP samples as the VCF we will deliver to Elizabeth Atkinson's team needs to have these samples so they can further subset and build a reference panel from HGDP and TGP for local ancestry inference.  I've included site statistics like QD, FS, and MQ as the gnomAD production team uses these when running QC and I wanted Elizabeth's team to have the option to do further QC on the exported VCF. 

To test this I ran 
```
hailctl dataproc submit mw subset_vcf_for_phase.py --test --pop afr --contigs chr1 --hgdp --tgp --output-path gs://gnomad-tmp-4day/mwilson/lai/afr --overwrite
```

@KoalaQin , please let me know if you have any questions regarding the project if they would help with your review. Thank you!